### PR TITLE
Update sudo.rb

### DIFF
--- a/lib/facter/sudo.rb
+++ b/lib/facter/sudo.rb
@@ -1,8 +1,7 @@
 Facter.add("sudoversion") do
   confine :kernel => 'Linux'
-  ENV["PATH"]="/bin:/sbin:/usr/bin:/usr/sbin"
-
   setcode do
+    ENV["PATH"]="/bin:/sbin:/usr/bin:/usr/sbin"
     output = `sudo -V 2>&1`
     if $?.exitstatus.zero?
       m = /Sudo version ([\d\.]+)/.match output

--- a/lib/facter/sudo.rb
+++ b/lib/facter/sudo.rb
@@ -1,4 +1,5 @@
 Facter.add("sudoversion") do
+  confine :kernel => 'Linux'
   ENV["PATH"]="/bin:/sbin:/usr/bin:/usr/sbin"
 
   setcode do


### PR DESCRIPTION
Hi,

Update sudo.rb to confine the fact to be available only for linux machines. This fixes an issue in windows clients. Our environment has linux and windows machines. The fact is overriding PATH variable on windows clients too, which is causing issues with all other things.

You could see the issue i am discussing here : https://ask.puppetlabs.com/question/1610/provider-windows-is-not-functional-on-this-host-windows-2008/

Restricting the fact for linux machines fixes the problem on windows. I verified the change on my machines.

Could you please take a look ?
