### PR TITLE
Adding newline to $content

### DIFF
--- a/manifests/directive.pp
+++ b/manifests/directive.pp
@@ -83,7 +83,7 @@ define sudo::directive(
                 default: { $real_source = $source }
             }
         }
-        default: { $real_content = $content }
+        default: { $real_content = "${content}\n" }
     }
 
     if versioncmp($::sudoversion,'1.7.2') < 0 {


### PR DESCRIPTION
visudo was constantly failing, until I realised that it needs a newline at the end of each sudoers.d file here's the fix.
