### PR TITLE
Fix variable access

### DIFF
--- a/manifests/alias/user.pp
+++ b/manifests/alias/user.pp
@@ -67,7 +67,7 @@ define sudo::alias::user(
 
     concat::fragment { "sudoers_user_aliases_${groupname}":
         target  => $sudo::configfile,
-        content => inline_template("User_Alias <%= groupname.upcase %> = <%= userlist.join(', ') %>\n"),
+        content => inline_template("User_Alias <%= @groupname.upcase %> = <%= @userlist.join(', ') %>\n"),
         order   => $order,
         notify  => Exec[$sudo::params::check_syntax_name],
     }


### PR DESCRIPTION
This fixes long deprecated variable access:

Warning: Variable access via 'groupname' is deprecated. Use '@groupname' instead. template[inline]:1
