### PR TITLE
Reinstate the newline at the end of $real_content

### DIFF
--- a/manifests/directive.pp
+++ b/manifests/directive.pp
@@ -77,7 +77,7 @@ define sudo::directive(
     $real_content = $content ? {
         '' => undef,
         default => $source ? {
-            ''      => $content,
+            ''      => "${content}\n",
             default => undef
         }
     }


### PR DESCRIPTION
Changeset 66824416 changed how real_source and real_content are
determined, but at the same time accidentally reversed the fix from
changeset c17b17619 that added a newline at the end of $content to
prevent visudo from erroring.