### PR TITLE
Added check for whether $ensure value is 'present' or not since previ…

### DIFF
--- a/manifests/directive.pp
+++ b/manifests/directive.pp
@@ -102,22 +102,27 @@ define sudo::directive(
         }
         else
         {
-            # here sudo version >= 1.7.2
-            #
-            # The #includedir directive is present to manage sudoers.d, version >= 1.7.2
-            #
-            file {"${sudo::configdir}/${dname}":
-                ensure  => $ensure,
-                owner   => $sudo::params::configfile_owner,
-                group   => $sudo::params::configfile_group,
-                mode    => $sudo::params::configfile_mode,
-                content => $real_content,
-                source  => $real_source,
-                notify  => Exec["${sudo::params::check_syntax_name} for ${sudo::params::configdir}/${dname}"],
-                require => File[$sudo::configdir],
-                #Package['sudo'],
+            if $ensure == 'present' {
+                # here sudo version >= 1.7.2
+                #
+                # The #includedir directive is present to manage sudoers.d, version >= 1.7.2
+                #
+                file {"${sudo::configdir}/${dname}":
+                    ensure  => $ensure,
+                    owner   => $sudo::params::configfile_owner,
+                    group   => $sudo::params::configfile_group,
+                    mode    => $sudo::params::configfile_mode,
+                    content => $real_content,
+                    source  => $real_source,
+                    notify  => Exec["${sudo::params::check_syntax_name} for ${sudo::params::configdir}/${dname}"],
+                    require => File[$sudo::configdir],
+                    #Package['sudo'],
+                }
+            } else {
+                file {"${sudo::configdir}/${dname}":
+                    ensure => $ensure,
+                }
             }
-
             if $sudo::ensure == 'present' {
                 # check the syntax of the created files, delete it if the syntax is wrong
                 exec {"${sudo::params::check_syntax_name} for ${sudo::params::configdir}/${dname}":
@@ -127,7 +132,6 @@ define sudo::directive(
                     logoutput   => 'on_failure',
                     refreshonly => true,
                 }
-
             }
         }
     }


### PR DESCRIPTION
…ously the 'require' parameter was being triggered when the resource was absent, triggering a syntax check on an absent file.